### PR TITLE
sql30: Allow database or its schema export

### DIFF
--- a/sql30/db.py
+++ b/sql30/db.py
@@ -135,6 +135,27 @@ class Model(object):
         """
         return self
 
+    def export(self, dbfile='db.scehma', schema_only=False):
+        """
+        Exports whole database in a file with SQL statements. This
+        file can then be taken anywhere and database can be reconstructed
+        by following command :
+            $ sqlite3 my_backup.db < db.schema
+
+        Parameters
+        -----------
+        dbfile : str
+            Path and filename to be dumped. Defaults to db.schema
+        schema_only : bool
+            Dumps only schema and not the data when set to True ; default False.
+        """
+
+        with open(dbfile, 'w+') as fp:
+            for line in self.connection.iterdump():
+                if schema_only and line.startswith('INSERT INTO'):
+                    continue
+                fp.write('%s\n' % line)
+
     def init_db(self, schema):
         '''
         Initializes Databse using schema by creating tables specified in

--- a/sql30/tests/reviews.py
+++ b/sql30/tests/reviews.py
@@ -6,6 +6,7 @@ import unittest
 from sql30 import db
 
 DB_NAME = './review.db'
+BACKUP_DB = './review_backup.db'
 
 
 class Reviews(db.Model):
@@ -107,11 +108,22 @@ class ReviewTest(unittest.TestCase):
         db.commit()
         self.assertFalse(db.read(rid=2))
 
+    def _test_export(self):
+        db = Reviews()
+        db.export(dbfile=BACKUP_DB) 
+
     def test_CRUD(self):
         self._test_CREATE()
         self._test_READ()
         self._test_UPDATE()
+        
+        # Export file and ensure it exists.
+        self._test_export()
+        assert os.path.exists(BACKUP_DB)
+        os.remove(BACKUP_DB)
+
         self._test_DELETE()
 
     def tearDown(self):
         os.remove(DB_NAME)
+        


### PR DESCRIPTION
Change for :
    - Allow schema to be dumped.
    - Allow whole databse to be dumped through simple SQL statements.