### PR TITLE
SQL30_DB_DIR , HTTP server for data browsing and minor fixes

### DIFF
--- a/sql30/api.py
+++ b/sql30/api.py
@@ -50,7 +50,7 @@ class SQL30Handler(BaseHTTPRequestHandler):
             return json.dumps(records)
 
 
-def run(db_path, server=ThreadingHTTPServer, handler=SQL30Handler, port=8008):
+def start_server(db_path, server=ThreadingHTTPServer, handler=SQL30Handler, port=8008):
     global DBPATH
     DBPATH = db_path
 
@@ -63,6 +63,6 @@ def run(db_path, server=ThreadingHTTPServer, handler=SQL30Handler, port=8008):
 
 if __name__ == "__main__":
     if len(argv) >= 2:
-        run(argv[1], port=int(argv[2]))
+        start_server(argv[1], port=int(argv[2]))
     else:
-        run(None)
+        start_server(None)

--- a/sql30/tests/sanity.py
+++ b/sql30/tests/sanity.py
@@ -95,9 +95,6 @@ class TestReviews(object):
 
         # TEST CASE 3: Delete a record with primary key = 2
         where = {'rid': 2}
-        values = {
-                'rating': 2
-                }
 
         print("Updating record with id '2'")
         db.update(tbl, condition=where,

--- a/sql30/tests/sanity.py
+++ b/sql30/tests/sanity.py
@@ -4,10 +4,14 @@ A simple sanity test for sql30 module.
 
 If this module runs on your platform ( UNIX, WINDOWS, ESX etc.) you can use
 this module.
+
+USAGE: 
+     python -msql30.tests.sanity
 '''
 import os
 import sqlite3
 import sys
+import unittest
 
 from sql30 import db
 
@@ -36,8 +40,8 @@ class Reviews(db.Model):
 # unittest module. On some platforms like ESX, if unittest module is
 # not ported yet, this sanity check will fail. To handle that, it is
 # shown as pure python test case.
-# class TestReviews(unittest.TestCase):
-class TestReviews(object):
+class TestReviews(unittest.TestCase):
+# class TestReviews(object):
 
     DB_NAME = './test_reviews.db'
 

--- a/sql30/tests/testPath.py
+++ b/sql30/tests/testPath.py
@@ -1,0 +1,108 @@
+"""
+Unittest for testing SQL30_DB_DIR based path feature.
+
+NOTE: This test file is deliberately not named as test_path.py
+but rather as testPath.py. It is because this test modifes the
+local environment variable and hence must be run separately.
+
+All the test_*.py tests are run together.
+"""
+
+import os
+import tempfile
+import unittest
+
+from sql30 import db
+
+DB_NAME = './path.db'
+
+
+class Square(db.Model):
+    TABLE = 'square'
+    PKEY = 'num'
+    DB_SCHEMA = {
+        'db_name': DB_NAME,
+        'tables': [
+            {
+                'name': TABLE,
+                'fields': {
+                    'num': 'int',
+                    'square': 'int',
+                    },
+                'primary_key': PKEY
+            }]
+        }
+    VALIDATE_BEFORE_WRITE = True
+    INIT_CONNECTION = True
+
+
+class PathTest(unittest.TestCase):
+
+    TABLE = 'square'
+
+    def setUp(self):
+        """
+        setUp is run before each test.
+        """
+        # Chose a temporary directory for DB file path.
+        self.db_test_dir = tempfile.mkdtemp()
+
+        os.environ['SQL30_DB_DIR'] = self.db_test_dir
+
+        self.db_path = os.path.join(self.db_test_dir, DB_NAME)
+
+        self.db = Square()
+        self.db.table = self.TABLE
+
+        # Populate 3 records for validating queries later.
+        self.db.write(num=1, square=1)
+        self.db.write(num=2, square=4)
+        self.db.write(num=3, square=9)
+        self.db.commit()
+
+    def test_db_path(self):
+        """
+        Test - SQL30_DB_DIR honored.
+        """
+        assert os.path.exists(self.db_path)
+
+    def test_db_path_matches(self):
+        """
+        Test - SQL30_DB_DIR honored for future operations.
+        """
+        with Square() as db:
+            msg = "DB file path error."
+            assert os.path.samefile(db._db, self.db_path), msg
+
+    def test_db_loc_path(self):
+        """
+        Test - SQL30_DB_DIR overrides db_loc argument.
+        """
+        with Square(db_loc='./does/not/matter/') as db:
+            msg = "DB file path error."
+            assert os.path.samefile(db._db, self.db_path), msg
+
+            db.table = self.TABLE
+            # case 1: Total numnber of records should be 3.
+            self.assertEqual(db.count(), 3)
+
+            # Number of records where num is 2 should be 1.
+            self.assertEqual(db.count(num=2), 1)
+
+            # Number of records where square is 9 should be 1.
+            self.assertEqual(db.count(square=9), 1)
+
+            # Number of records where 4 <= square <= 9 should be 1.
+            self.assertEqual(db.count(square=[4, 9]), 2)
+
+    def tearDown(self):
+        """
+        tearDown is run after each test.
+        """
+        os.remove(self.db_path)
+
+        # Do not use shtutil.rmtree() as it will delete contents
+        # automatically. Delete using os.rmdir() insteas as it
+        # expects directory to be empty which becomes another test
+        # to ensure only one file was created by this test.
+        os.rmdir(self.db_test_dir)

--- a/tests.sh
+++ b/tests.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "Running tests in python 3"
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "Running tests in python 3"
+echo "===================================="
+echo "Running tests using python 3"
+echo "===================================="
 python3 -m unittest discover -p "test_*.py" sql30/tests/ -v
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+python3 -m unittest discover -p testPath.py sql30/tests/ -v
+echo "===================================="
+echo ""
+echo ""
+echo ""
+echo "===================================="
 echo "Running tests in python 2 "
+echo "===================================="
 python2 -m unittest discover -p "test_*.py" sql30/tests/ -v
-echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+python2 -m unittest discover -p testPath.py sql30/tests/ -v
+echo "===================================="

--- a/tests.sh
+++ b/tests.sh
@@ -5,6 +5,7 @@ echo "Running tests using python 3"
 echo "===================================="
 python3 -m unittest discover -p "test_*.py" sql30/tests/ -v
 python3 -m unittest discover -p testPath.py sql30/tests/ -v
+python3 -m unittest discover -p sanity.py sql30/tests/ -v
 echo "===================================="
 echo ""
 echo ""


### PR DESCRIPTION
Changes for : 

- Allow users to redirect db files into a directory based on  SQL30_DB_DIR .
- Fix command line utility to start server on a port to serve data of tables.
- Include sanity test into the unit tests which are gating tests for release of sql30.
- Minor styling fixes.